### PR TITLE
Fixed unmatched brace in bigchain.bib so 'set -e' could be added to build.sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -e
+
 FILENAME='bigchaindb-whitepaper.pdf'
 FILENAME_PRIMER='bigchaindb-primer.pdf'
 

--- a/src/bigchain.bib
+++ b/src/bigchain.bib
@@ -149,7 +149,7 @@
 }
 
 @misc{bitcoin_tx_fees_2017,
-  title = {{Bitcoin Transaction Fees Are Up More Than 1200\% in Past Two Years},
+  title = {{Bitcoin Transaction Fees Are Up More Than 1200\% in Past Two Years}},
   howpublished = {\url{https://news.bitcoin.com/bitcoin-transaction-fees-1200-past-two-years/}},
   author = {Justin Connell},
   year = {2017},


### PR DESCRIPTION
It was easier than expected to fix `bigchain.bib` so that adding `set -e` to `build.sh` didn't cause a catastrophic fail when `build.sh` was run.